### PR TITLE
Port Python scripts to Python 3

### DIFF
--- a/bin/make_json.py
+++ b/bin/make_json.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 
+import os
+import sys
+
+# Allow running without installing the library as a package
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib", "python"))
+
 from Header import Header
 from HeaderLib import exploreHeader, readHeaders, DONE
 from Field import Field
 import string
-import sys
 import re
 import argparse
 from pyparsing import *
@@ -29,10 +34,10 @@ def resetVars():
 def matchToVerilog(match):
     """Concert a match array pair to a verilog string"""
     matchStr = "%d'b" % (len(match[0]) * 8)
-    for j in xrange(len(match[0])):
+    for j in range(len(match[0])):
         maskByte = match[0][j]
         dataByte = match[1][j]
-        for k in xrange(8):
+        for k in range(8):
             if maskByte & (0x80 >> k):
                 matchStr += "%d" % ((dataByte & (0x80 >> k)) >> (7 - k))
             else:
@@ -52,7 +57,7 @@ def processHdrStart(hdr, nxtHdr, headers, hdrInfo, pos = 0, hdrSeq = []):
         exploreHeader(nxtHdr, headers, phsFunc)
     else:
         hdrSeqStr = ""
-        for i in xrange(0, len(hdrSeq), 3):
+        for i in range(0, len(hdrSeq), 3):
             hdrSeqStr += "%s:%d:%d==" % (hdrSeq[i], hdrSeq[i+1], hdrSeq[i+2])
         if hdrSeqStr not in hdrSeqStrs:
             hdrSeqStrs.add(hdrSeqStr)
@@ -78,7 +83,7 @@ def generateJSONObject(hdr, headers, hdrInfo):
             hdrDict['len'] = 0
             hdrDict['lenBytes'] = hdrInfo.lenBytes
             lenMap = {}
-            for i in xrange(len(hdrInfo.lengths)):
+            for i in range(len(hdrInfo.lengths)):
                 lenMatch = matchToVerilog(hdrInfo.lenMatch[i])
                 length = hdrInfo.lengths[i]
                 lenMap[lenMatch] = length
@@ -89,7 +94,7 @@ def generateJSONObject(hdr, headers, hdrInfo):
         if len(hdrInfo.nxtHdrs) > 0:
             hdrDict['nxtHdrBytes'] = hdrInfo.nxtHdrBytes
             nxtHdrMap = {}
-            for i in xrange(len(hdrInfo.nxtHdrs)):
+            for i in range(len(hdrInfo.nxtHdrs)):
                 nxtHdrMatch = matchToVerilog(hdrInfo.nxtHdrMatch[i])
                 nxtHdr = hdrInfo.nxtHdrs[i]
                 if nxtHdr:
@@ -127,12 +132,12 @@ def generateJSON(headerList, headers, dstFile = None):
     exploreHeader(headerList[0], headers, generateJSONObject, False)
 
     if dstFile is None:
-        print json.dumps(indent = 4, obj =
+        print(json.dumps(indent = 4, obj =
                 {
                     'firstHdr': orderedHdrs[0],
                     'headers': simpleHdrs,
                     'hdrSeqs': hdrSeqs,
-                })
+                }))
     else:
         f = open(dstFile, 'w')
         json.dump(indent = 4, fp = f, obj =

--- a/bin/make_tcam.py
+++ b/bin/make_tcam.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python
 
+import os
+import sys
+
+# Allow running without installing the library as a package
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib", "python"))
+
 from Header import Header, ANY
 from Field import Field
 import string
-import sys
 import re
 import copy
 import math
@@ -16,6 +21,7 @@ from DAGChain import DAGChain
 from DAGChainNode import DAGChainNode
 from OptNode import OptNode
 import time
+from functools import cmp_to_key
 #from LookupChain import LookupChain
 import argparse
 import cProfile
@@ -193,13 +199,13 @@ def optFound(context):
 
 def printBestOpt(context, printEdges=True):
     if len(context.optNodes) > 0:
-        print "opt-algorithm best edge count: %d" % context.bestEdgeCount
-        print "opt-algorithm worst bits-per-cycle: %1.3f   (%1.3f bytes-per-cycle)" % \
-                (context.worstBPC, context.worstBPC / 8)
+        print("opt-algorithm best edge count: %d" % context.bestEdgeCount)
+        print("opt-algorithm worst bits-per-cycle: %1.3f   (%1.3f bytes-per-cycle)" % \
+                (context.worstBPC, context.worstBPC / 8))
         if printEdges:
-            print "opt-algorithm optimal clusters:"
+            print("opt-algorithm optimal clusters:")
             for cluster in sorted(context.bestClusters):
-                print "  %s   (%d edges)" % (cluster, findEdgeCount(context, cluster))
+                print("  %s   (%d edges)" % (cluster, findEdgeCount(context, cluster)))
                 #cnode = DAGChainNode(cluster.chain[0].dagNode, cluster.chain[0].startPos, 0, 0)
                 #coveredClusters = findClustersAndCovers(cnode)
                 #fringe = findFringeWithMinCoverLen(cluster, coveredClusters)
@@ -208,17 +214,17 @@ def printBestOpt(context, printEdges=True):
                 #    print f,
                 #print ""
     else:
-        print "opt-algorithm could not find optimal that met required BPC (%d) or minimum skip amount (%d)" % (globalBPC, minSkip)
+        print("opt-algorithm could not find optimal that met required BPC (%d) or minimum skip amount (%d)" % (globalBPC, minSkip))
 
 def printEntries(context):
     if len(context.optNodes) > 0:
-        print "opt-algorithm TCAM entries:"
+        print("opt-algorithm TCAM entries:")
         for cluster in sorted(context.bestClusters):
-            print "  %s   (%d edges)" % (cluster, findEdgeCount(context, cluster))
+            print("  %s   (%d edges)" % (cluster, findEdgeCount(context, cluster)))
             cnode = cluster.chain[0]
             coveredClusters = findClustersAndCovers(context, cnode)
             for entry in sorted(coveredClusters[cluster]):
-                print "     %s" % entry
+                print("     %s" % entry)
 
 def numStatesNeeded(chain):
     """Identify the number of states needed by a chain"""
@@ -319,7 +325,7 @@ def cmpMaskMatchArray(a, b):
     aLen = len(aMaskArray)
     bLen = len(bMaskArray)
     minLen = min(aLen, bLen)
-    for i in xrange(minLen):
+    for i in range(minLen):
         aMask = aMaskArray[i]
         bMask = bMaskArray[i]
         aMatch = aMatchArray[i]
@@ -327,7 +333,7 @@ def cmpMaskMatchArray(a, b):
 
         aMaskBits = 0
         bMaskBits = 0
-        for bit in xrange(8):
+        for bit in range(8):
             if aMask & (2 ** bit) != 0:
                 aMaskBits += 1
             if bMask & (2 ** bit) != 0:
@@ -351,11 +357,11 @@ def cmpMaskMatchArray(a, b):
     return 0
 
 def cmpMatchBytesStr(a, b):
-    aByteArray = map(ord, a.decode('hex'))
+    aByteArray = list(bytes.fromhex(a))
     aMaskArray = aByteArray[0::2]
     aMatchArray = aByteArray[1::2]
 
-    bByteArray = map(ord, b.decode('hex'))
+    bByteArray = list(bytes.fromhex(b))
     bMaskArray = bByteArray[0::2]
     bMatchArray = bByteArray[1::2]
 
@@ -386,12 +392,12 @@ def allocateState(context, chain, availableState):
             endPos = startPos
         elif arraySpan == statesNeeded and \
                 span == statesNeeded:
-            matchBytes = sorted(findPrecedingMatchBytes(chain), cmpMatchBytesStr)
+            matchBytes = sorted(findPrecedingMatchBytes(chain), key=cmp_to_key(cmpMatchBytesStr))
             if len(matchBytes) > 0 and len(matchBytes[0]) > 0:
-                mask = map(ord, matchBytes[0].decode('hex'))[0::2]
+                mask = list(bytes.fromhex(matchBytes[0]))[0::2]
                 for mb in matchBytes[1:]:
-                    newMask = map(ord, mb.decode('hex'))[0::2]
-                    for i in xrange(len(mask)):
+                    newMask = list(bytes.fromhex(mb))[0::2]
+                    for i in range(len(mask)):
                         mask[i] |= newMask[i]
             else:
                 mask = []
@@ -399,7 +405,7 @@ def allocateState(context, chain, availableState):
             context.allocation[ingress] = availableState[startPos]
             context.matchBytes[ingress] = matchBytes
             context.matchMask[ingress] = mask
-            print "CHAIN:", chain, matchBytes
+            print("CHAIN:", chain, matchBytes)
             del availableState[startPos:endPos + 1]
             return True
         elif span != arraySpan:
@@ -571,7 +577,7 @@ def printTCAMEntry(context, chain):
     covers = findClustersAndCovers(context, cnode)[chain]
     entries = []
     for cover in sorted(covers):
-        print chain, cover
+        print(chain, cover)
 
         lookupValues = cover.getLookupByteValues(False)
         if len(lookupValues) == 0:
@@ -620,7 +626,7 @@ def printTCAMEntry(context, chain):
             nxtLookupStarts.append(0)
 
         skip = cover.totalConsumed()
-        for lookupValueFull in sorted(lookupValues, cmpMatchBytesStr, reverse=True):
+    for lookupValueFull in sorted(lookupValues, key=cmp_to_key(cmpMatchBytesStr), reverse=True):
             stateInBytes = lookupValueFull[0:baseMatchByteLen]
             if successorMatchByteLen > 0:
                 stateOutBytes = lookupValueFull[-successorMatchByteLen:]
@@ -628,8 +634,8 @@ def printTCAMEntry(context, chain):
                 stateOutBytes = ''
 
             #print "SOBi:", stateOutBytes
-            stateOutBytes = map(ord, stateOutBytes.decode('hex'))
-            for i in xrange(len(successorMatchMask)):
+            stateOutBytes = list(bytes.fromhex(stateOutBytes))
+            for i in range(len(successorMatchMask)):
                 stateOutBytes[i*2] &= successorMatchMask[i]
                 stateOutBytes[i*2+1] &= successorMatchMask[i]
             stateOutBytes = ''.join(["%02x" % x for x in stateOutBytes])
@@ -638,45 +644,45 @@ def printTCAMEntry(context, chain):
 
             prevMatchBytes = context.matchBytes[chain.ingress()]
             if len(prevMatchBytes) == 0:
-                print "YUP"
+                print("YUP")
                 prevMatchBytes = set('')
-            print "cover: %s   lookupValue:%s   stateInBytes: %s   prevMatchBytes: %s" % (cover, lookupValueFull, stateInBytes, prevMatchBytes)
-            stateInBytesAsArray = map(ord, stateInBytes.decode('hex'))
+            print("cover: %s   lookupValue:%s   stateInBytes: %s   prevMatchBytes: %s" % (cover, lookupValueFull, stateInBytes, prevMatchBytes))
+            stateInBytesAsArray = list(bytes.fromhex(stateInBytes))
             stateInBytesMask = stateInBytesAsArray[0::2]
             stateInBytesMatch = stateInBytesAsArray[1::2]
             for pmb in prevMatchBytes:
-                pmbAsArray = map(ord, pmb.decode('hex'))
+                pmbAsArray = list(bytes.fromhex(pmb))
                 pmbMask = pmbAsArray[0::2]
                 pmbMatch = pmbAsArray[1::2]
 
                 # Check if the masks are compatible
                 compat = True
-                for i in xrange(len(pmbMask)):
+                for i in range(len(pmbMask)):
                     compat &= (stateInBytesMask[i] & pmbMask[i]) ^ stateInBytesMask[i] == 0
                     compat &= (stateInBytesMask[i] & pmbMatch[i]) == (stateInBytesMask[i] & stateInBytesMatch[i])
 
-                print "COMPAT:", compat, stateInBytes, pmb
+                print("COMPAT:", compat, stateInBytes, pmb)
 
                 if not compat:
                     continue
 
                 lookupValue = lookupValueFull[baseMatchByteLen:]
-                print "cover: %s   lookupValue:%s   stateInBytes (pmb): %s   stateOutBytes: %s" % (cover, lookupValue, pmb, stateOutBytes)
+                print("cover: %s   lookupValue:%s   stateInBytes (pmb): %s   stateOutBytes: %s" % (cover, lookupValue, pmb, stateOutBytes))
                 stateIn = baseMatchBytes.index(pmb) + baseState
                 stateOut = successorMatchBytes.index(stateOutBytes) + successorState
 
                 #print cover, cover.getLookupByteValues(False)
-                mask = [0 for x in xrange(lookups * lookupWidth)]
-                match = [0 for x in xrange(lookups * lookupWidth)]
-                lookupValueByteArray = map(ord, lookupValue.decode('hex'))
-                for i in xrange(len(lookupValueByteArray) / 2):
+                mask = [0 for x in range(lookups * lookupWidth)]
+                match = [0 for x in range(lookups * lookupWidth)]
+                lookupValueByteArray = list(bytes.fromhex(lookupValue))
+                for i in range(len(lookupValueByteArray) // 2):
                     dest = lookupMap[i]
                     mask[dest] = lookupValueByteArray[i*2]
                     match[dest] = lookupValueByteArray[i*2+1]
 
                 stateMask = []
                 stateMatch = []
-                for i in xrange(stateBytes):
+                for i in range(stateBytes):
                     maskVal = 255
                     if i == stateBytes - 1:
                         maskVal = 2 ** (stateBits % 8) - 1
@@ -745,7 +751,7 @@ def printTCAMEntry(context, chain):
                         base += node.consumed
                         #print "EXT:", nodeName, nodeExtractBytes
                     #entryStr += '   Extract: [%s]' % (', '.join('(%d, %d)' % (src, dst) for (src, dst) in coverExtractBytes))
-                    coverExtractBytes.extend([(0, 0) for x in xrange(extractBytes - len(coverExtractBytes))])
+                    coverExtractBytes.extend([(0, 0) for x in range(extractBytes - len(coverExtractBytes))])
                     entryStr += '   Extract: [%s]' % (', '.join(extractFmtStr % (src, dst) for (src, dst) in coverExtractBytes))
                     #print "EXT:", coverExtractBytes
 
@@ -764,7 +770,7 @@ def printTCAMEntry(context, chain):
                             starts.append((context.foundHdrNum[nodeStr], pos, len(context.fieldPos[nodeStr])))
                     pos += node.consumed
                 #entryStr += '   Hdr-Starts: [%s]' % (', '.join('(%d, %d)' % (hdr, pos) for (hdr, pos) in starts))
-                starts.extend([(0, 0, 0) for x in xrange(maxHdrs - len(starts))])
+                starts.extend([(0, 0, 0) for x in range(maxHdrs - len(starts))])
                 entryStr += '   Hdr-Starts: [%s]' % (', '.join(hdrStartFmtStr % (pos, hdr, length) for (hdr, pos, length) in starts))
 
                 #print "  %s   # Match: %s   Nxt-State: %d" % (entryStr, cover, stateOut)
@@ -779,9 +785,9 @@ def printTCAMEntry(context, chain):
             if wildcardMatch:
                 break
 
-    for (mask, match, entryStr, commentStr) in sorted(entries, cmpEntry):
+    for (mask, match, entryStr, commentStr) in sorted(entries, key=cmp_to_key(cmpEntry)):
         if printTCAM:
-            print "  %s     # %s" % (entryStr, commentStr)
+            print("  %s     # %s" % (entryStr, commentStr))
         if saveTCAM:
             tcamFile.write("  %s     # %s\n" % (entryStr, commentStr))
 
@@ -836,7 +842,7 @@ def printTCAMEntries(context):
         #    print cluster, isNextNodeInSameHdr(context, cluster)
 
         # Allocate state to each cluster
-        availableState = range(tcamMaxState)
+        availableState = list(range(tcamMaxState))
         context.allocation = {}
         context.matchBytes = {}
         context.matchMask = {}
@@ -846,7 +852,7 @@ def printTCAMEntries(context):
                 if cluster == firstCluster:
                     continue
                 if not allocateState(context, cluster, availableState):
-                    print "Insufficient state available for table"
+                    print("Insufficient state available for table")
                     return
         #for cluster in sorted(context.bestClusters):
         #    #print cluster, context.allocation[cluster.ingress()]
@@ -863,7 +869,7 @@ def printTCAMEntries(context):
         if saveTCAM:
             tcamFile = open(dstFileName, 'w')
         if printTCAM:
-            print "tcam-entries:"
+            print("tcam-entries:")
 
         firstNode = context.dagOrderList[0]
         for firstChain in context.bestClusters:
@@ -884,7 +890,7 @@ def printTCAMEntries(context):
             firstLookupStarts.append(0)
         firstLookupStr = 'First-Lookup: [%s]' % (', '.join('%d' % val for val in firstLookupStarts))
         if printTCAM:
-            print "  %s" % firstLookupStr
+            print("  %s" % firstLookupStr)
         if saveTCAM:
             tcamFile.write("  %s\n" % firstLookupStr)
 
@@ -1053,19 +1059,19 @@ def exploreGraph(context, cnode):
         #print "RS-Size:", len(resultSets), lenSum
 
     if debug:
-        print "exploreGraph: N=%s" % (cnode)
-        print "  Results:"
+        print("exploreGraph: N=%s" % (cnode))
+        print("  Results:")
         for (clusters, byteCount, cyc) in results:
             #print "  Result:"
             for cluster in sorted(clusters):
-                print "    %s" % cluster
-        print ""
+                print("    %s" % cluster)
+        print("")
         resultCount = 0
         for (clusters, byteCount, cyc) in results:
             resultCount += len(clusters)
-        print "  ResultCount:", resultCount
-        print "  Counts: %d   Combs: %d" % (counts, combs)
-        print ""
+        print("  ResultCount:", resultCount)
+        print("  Counts: %d   Combs: %d" % (counts, combs))
+        print("")
 
     #global resultsRet
     #resultsRet += 1
@@ -1253,7 +1259,7 @@ def findClustersAndCovers(context, cnode):
     #        print "  ", cover
     #print ""
     context.coveredClustersFromNode[cnode] = coveredClusters
-    context.clustersFromNode[cnode] = sorted(coveredClusters.keys())
+    context.clustersFromNode[cnode] = sorted(coveredClusters.keys(), key=lambda c: c.shortStr())
 
     return coveredClusters
 
@@ -1380,16 +1386,17 @@ def findCoveredClusters(clusters):
     #    for r in sorted(reachableNewHdr[subchain]):
     #        print "      ", r
     #sys.exit(1)
-    for cluster in reachableNewHdr.keys():
+    for cluster in list(reachableNewHdr.keys()):
         #print "CLU:", cluster
         subchains = cluster.findLookupSubchains()
 
         # Calculate the set of nodes reachable from the current cluster
         targets = set()
-        for subchain in sorted(subchains):
+        subchains_sorted = sorted(subchains, key=lambda c: c.shortStr())
+        for subchain in subchains_sorted:
             #print "Add:", subchain
             targets.update(reachableNewHdr[subchain])
-        targets.update(reachableSameHdr[subchains[-1]])
+        targets.update(reachableSameHdr[subchains_sorted[-1]])
         #for t in sorted(targets):
         #    print "T:", t
 
@@ -1496,11 +1503,11 @@ def findReachable(chains,
     reachableNewHdr = dict()
     reachableSameHdr = dict()
     #for chain in chains:
-    for chain in sorted(chains):
+    for chain in sorted(chains, key=lambda c: c.shortStr()):
         #print "CH:", chain
         lookupSubchains = chain.findLookupSubchains()
         #for lc in lookupSubchains:
-        for lc in sorted(lookupSubchains):
+        for lc in sorted(lookupSubchains, key=lambda c: c.shortStr()):
             #print "   LC:", lc
             #continue
             if lc not in reachableNewHdr:
@@ -1663,7 +1670,7 @@ def buildDAG(headerList, headers):
 def addPad(dagNodes):
     """Add pad nodes to a DAG"""
     newNodes = {}
-    for key in dagNodes.keys():
+    for key in list(dagNodes.keys()):
         node = dagNodes[key]
         lengths = node.getLengths()
         if len(lengths) > 1: # or lengths[0] > maxSkip:
@@ -1702,36 +1709,36 @@ estReportTime = 10
 countEstimated = False
 
 def printParams():
-    print "TCAM entry evaluation"
-    print "====================="
-    print ""
-    print "Header file: %s" % hfile
-    print "Data rate: %1.3f Gb/s" % dataRate
-    print "Clock frequency: %1.3f GHz" % clkFreq
-    print "Required processing rate: %1.3f bpc" % globalBPC
-    print "Lookups: %d" % lookups
-    print "Lookup width: %d bytes" % lookupWidth
-    print "Maximum skip: %d bytes" % maxSkip
-    print "Minimum skip: %d bytes" % minSkip
-    print "First lookup at zero: %s" % firstLookupAtZero
-    print "Window size: %d bytes" % windowSize
-    print "Perform extraction: %s " % extract
+    print("TCAM entry evaluation")
+    print("=====================")
+    print("")
+    print("Header file: %s" % hfile)
+    print("Data rate: %1.3f Gb/s" % dataRate)
+    print("Clock frequency: %1.3f GHz" % clkFreq)
+    print("Required processing rate: %1.3f bpc" % globalBPC)
+    print("Lookups: %d" % lookups)
+    print("Lookup width: %d bytes" % lookupWidth)
+    print("Maximum skip: %d bytes" % maxSkip)
+    print("Minimum skip: %d bytes" % minSkip)
+    print("First lookup at zero: %s" % firstLookupAtZero)
+    print("Window size: %d bytes" % windowSize)
+    print("Perform extraction: %s " % extract)
     if extract:
-        print "Extract: %d bytes" % extractBytes
+        print("Extract: %d bytes" % extractBytes)
     else:
-        print "Maximum headers/cycle: %d" % maxHdrs
-    print ""
-    print "Evaluations:"
-    print "  Multiple-parent merge: %s" % multParent
-    print "  Multiple-parent merge second pass: %s" % multParentRetry
-    print "  Parallel edge barriers: %s" % parallelEdge
-    print "  Combine clusters different by instance number: %s" % instMerge
-    print "  Ternary state matching: %s" % ternMatchOnState
-    print ""
-    print "Output:"
-    print "  Print TCAM entries: %s" % printTCAM
-    print "  Save TCAM entries: %s" % saveTCAM
-    print "  TCAM maximum state: %d" % tcamMaxState
+        print("Maximum headers/cycle: %d" % maxHdrs)
+    print("")
+    print("Evaluations:")
+    print("  Multiple-parent merge: %s" % multParent)
+    print("  Multiple-parent merge second pass: %s" % multParentRetry)
+    print("  Parallel edge barriers: %s" % parallelEdge)
+    print("  Combine clusters different by instance number: %s" % instMerge)
+    print("  Ternary state matching: %s" % ternMatchOnState)
+    print("")
+    print("Output:")
+    print("  Print TCAM entries: %s" % printTCAM)
+    print("  Save TCAM entries: %s" % saveTCAM)
+    print("  TCAM maximum state: %d" % tcamMaxState)
 
 def sortDAG(context):
     # Identify the parents
@@ -1765,7 +1772,7 @@ def sortDAG(context):
     while len(pending) > 0:
         curr = pending
         pending = set()
-        for node in sorted(curr):
+        for node in sorted(curr, key=lambda n: n.shortStr()):
             context.dagOrder[node] = depth
             context.dagOrderList.append(node)
             node.setTopo(depth, offset)
@@ -1830,15 +1837,15 @@ def cloneDAG(head):
 def findDAGNodes(dag, nodes):
     # Find the requested nodes
     nodeCount = len(nodes)
-    isFound = [False for node in xrange(nodeCount)]
-    foundNodes = [None for node in xrange(nodeCount)]
+    isFound = [False for node in range(nodeCount)]
+    foundNodes = [None for node in range(nodeCount)]
     toFind = nodeCount
 
     pending = [dag]
     seen = set(pending)
     while len(pending) > 0 and toFind:
         node = pending.pop(0)
-        for i in xrange(nodeCount):
+        for i in range(nodeCount):
             if not isFound[i]:
                 if nodes[i] == node:
                     foundNodes[i] = node
@@ -1964,7 +1971,7 @@ def printDAG(dag):
     seen = set(pending)
     while len(pending) > 0:
         node = pending.pop(0)
-        for nxt in sorted(node.nxt):
+        for nxt in sorted(node.nxt, key=lambda n: '' if n is None else n.shortStr()):
             if nxt and nxt not in seen:
                 seen.add(nxt)
                 pending.append(nxt)
@@ -1977,16 +1984,16 @@ def printDAG(dag):
             maxLen = strLen
 
     formatStr = '%%%ds   %%s' % maxLen
-    print formatStr % ('NODE', 'CHILDREN')
-    for node in sorted(seen):
+    print(formatStr % ('NODE', 'CHILDREN'))
+    for node in sorted(seen, key=lambda n: n.shortStr()):
         childStrs = []
-        for nxt in sorted(node.nxt):
+        for nxt in sorted(node.nxt, key=lambda n: '' if n is None else n.shortStr()):
             if nxt:
                 childStrs.append(nxt.shortStr())
             else:
                 childStrs.append('--')
         children = ', '.join(childStrs)
-        print formatStr % (node.shortStr(), children)
+        print(formatStr % (node.shortStr(), children))
         #nodeStr = '%s -> [' % node.shortStr()
         #firstChild = True
         #for nxt in sorted(node.nxt):
@@ -1999,7 +2006,7 @@ def printDAG(dag):
         #    firstChild = False
         #nodeStr += ']'
         #print nodeStr
-    print ""
+    print("")
 
 def printDAGParents(context):
     # Work out the length of the longest shortStr
@@ -2010,22 +2017,22 @@ def printDAGParents(context):
             maxLen = strLen
 
     formatStr = '%%%ds   %%s' % maxLen
-    print formatStr % ('NODE', 'PARENT')
+    print(formatStr % ('NODE', 'PARENT'))
     for node in ccontext.dagOrderList:
         if len(ccontext.dagParents[node]) > 0:
-            parentStr = ', '.join([parent.shortStr() for parent in sorted(ccontext.dagParents[node])])
+            parentStr = ', '.join([parent.shortStr() for parent in sorted(ccontext.dagParents[node], key=lambda n: n.shortStr())])
         else:
             parentStr = '--'
-        print formatStr % (node.shortStr(), parentStr)
+        print(formatStr % (node.shortStr(), parentStr))
         #for parent in ccontext.dagParents[node]:
         #    print parent.shortStr(),
         #print ""
 def runExplore(context):
     baseNode = DAGChainNode(context.dag, 0, 0, 0)
 
-    startTime = time.clock()
+    startTime = time.perf_counter()
     results = exploreGraph(context, baseNode)
-    endTime = time.clock()
+    endTime = time.perf_counter()
 
     timeDelta = endTime - startTime
 
@@ -2034,9 +2041,9 @@ def runExplore(context):
 def runOpt(context):
     baseNode = DAGChainNode(context.dag, 0, 0, 0)
 
-    startTime = time.clock()
+    startTime = time.perf_counter()
     opt(context, baseNode, globalBPC)
-    endTime = time.clock()
+    endTime = time.perf_counter()
 
     (context.worstBits, context.worstCyc) = findOptNodes(context, baseNode, globalBPC)
 
@@ -2053,7 +2060,7 @@ def runExploreAndOpt(context,
     expTime = runExplore(context)
 
     if showExpTime:
-        print "Graph exploration time: %1.03fs" % expTime
+        print("Graph exploration time: %1.03fs" % expTime)
 
     if printPathsToExplore:
         baseNode = DAGChainNode(context.dag, 0, 0, 0)
@@ -2064,20 +2071,20 @@ def runExploreAndOpt(context,
                 exp += 3
                 pathCount /= 1000
             pathCount /= 1000.0
-            print "Total paths to explore: %1.3f x 10^%d" % (pathCount, exp)
+            print("Total paths to explore: %1.3f x 10^%d" % (pathCount, exp))
         else:
-            print "Total paths to explore: %d" % pathCount
+            print("Total paths to explore: %d" % pathCount)
 
     optTime = runOpt(context)
 
     if showOptTime:
-        print "opt-algorithm runtime: %1.03fs" % optTime
-        print "opt-algorithm evaluation steps: %d" % context.count
+        print("opt-algorithm runtime: %1.03fs" % optTime)
+        print("opt-algorithm evaluation steps: %d" % context.count)
 
     if printResults:
         printBestOpt(context, printEdges)
 
-    print "\n"
+    print("\n")
 
 def combineClustersByInst(context):
     """
@@ -2118,7 +2125,7 @@ def combineClustersByInst(context):
                     pos += 1
 
     context.bestClusters = set()
-    for clusters in clustersByHdrPos.values():
+    for clusters in list(clustersByHdrPos.values()):
         context.bestClusters.update(clusters)
     context.bestEdgeCount = newEdgeCount
     #for (cnode, cluster) in context.optNodes:
@@ -2172,7 +2179,7 @@ def compareChainIgnoreInst(chainA, chainB, matchExactly=False):
     if aLen == 0 and bLen == 0:
         return chainA
 
-    for pos in xrange(min(len(chainA.chain), len(chainB.chain))):
+    for pos in range(min(len(chainA.chain), len(chainB.chain))):
         aNode = chainA.chain[pos]
         aHdrName = aNode.dagNode.getName()
         aPos = aNode.startPos
@@ -2220,7 +2227,7 @@ def updateDAGNodes(context):
                 seen.add(nxt)
 
 def tryDAGBarrier(context, node):
-    print "Procesing node '%s'   (Parents: %d)..." % (node, parentCount)
+    print("Procesing node '%s'   (Parents: %d)..." % (node, parentCount))
     posList = node.getDecisionBytes()
 
     # Trim temporarily
@@ -2232,13 +2239,13 @@ def tryDAGBarrier(context, node):
     posList.reverse()
     if 0 not in posList:
         posList.append(0)
-    print "Barrier locations:", posList
+    print("Barrier locations:", posList)
 
     roundBestContext = context
     roundBestLoc = None
     for barPos in posList:
     #for barPos in [0,4,20,40]:
-        print "Considering %d..." % barPos
+        print("Considering %d..." % barPos)
 
         newContext = OptContext()
         newContext.dag = cloneDAG(context.dag)
@@ -2259,23 +2266,23 @@ def tryDAGBarrier(context, node):
 def tryDAGParallelEdgeBarrier(context, node, nxtNode):
     edges = node.hdr.getDecisionCombos(
             nodeLen, nxtNode.hdr.name, nodeLen)
-    print "Processing edges between %s and %s (edges: %d)" % (node, nxtNode, edges)
+    print("Processing edges between %s and %s (edges: %d)" % (node, nxtNode, edges))
 
     posList = nxtNode.getDecisionBytes()
     # Trim temporarily
     if len(posList) > 0 and posList[-1] >= node.getLength():
         while len(posList) > 0 and posList[-1] > nxtNode.getLength():
-            print "Popping:", posList.pop()
+            print("Popping:", posList.pop())
     elif nxtNode.getLength() not in posList:
         posList.append(nxtNode.getLength())
     posList.reverse()
     if 0 not in posList:
         posList.append(0)
-    print "Barrier locations:", posList
+    print("Barrier locations:", posList)
     roundBestContext = context
     roundBestLoc = None
     for barPos in posList:
-        print "Considering %d..." % barPos
+        print("Considering %d..." % barPos)
 
         newContext = OptContext()
         newContext.dag = cloneDAG(context.dag)
@@ -2319,7 +2326,7 @@ def allocateResultVectorEntries(context):
 
             extractBytes = node.hdr.getExtractBytes()
             fieldPos = extractPos[node.hdr.name] + (node.inst - 1) * extractOffset[node.hdr.name]
-            extractBytes = zip(extractBytes, xrange(fieldPos, fieldPos + len(extractBytes)))
+            extractBytes = list(zip(extractBytes, list(range(fieldPos, fieldPos + len(extractBytes)))))
             context.fieldPos[nodeName] = extractBytes
 
             hdrNum += 1
@@ -2328,9 +2335,9 @@ def allocateResultVectorEntries(context):
     context.hdrCount = hdrNum + 1
     context.maxDest = fieldPos + 1
 
-    print "header-numbers:"
+    print("header-numbers:")
     for node in hdrs:
-        print "  %s: %d" % (node, context.foundHdrNum[node])
+        print("  %s: %d" % (node, context.foundHdrNum[node]))
 
 if __name__ == "__main__":
     my_parser = argparse.ArgumentParser('Read headers from a given file')
@@ -2451,7 +2458,7 @@ if __name__ == "__main__":
     stateWidth10 = int(math.ceil(math.log10(tcamMaxState)))
 
     if minSkip > 0:
-        print "Stopping: minSkip parameter does not work correctly. Specified: %d" % minSkip
+        print("Stopping: minSkip parameter does not work correctly. Specified: %d" % minSkip)
         sys.exit(1)
 
     printParams()
@@ -2472,13 +2479,13 @@ if __name__ == "__main__":
     sortDAG(ccontext)
     printDAGParents(ccontext)
 
-    print "\n\n\n"
-    print "Initial run:"
+    print("\n\n\n")
+    print("Initial run:")
     runExploreAndOpt(ccontext, showExpTime=True, showOptTime=True, printPathsToExplore=True, printEdges=True)
     bestContext = ccontext
 
     if multParent:
-        print "\nAttempting optimization of nodes with multiple parents...\n"
+        print("\nAttempting optimization of nodes with multiple parents...\n")
 
         barrierLocs = []
         unprocHeaders = []
@@ -2494,30 +2501,30 @@ if __name__ == "__main__":
                 unprocHeaders.append(node)
 
         if multParentRetry and len(unprocHeaders) > 0:
-            print "Retrying:",
+            print("Retrying:", end=' ')
             for h in unprocHeaders:
-                print h,
-            print ""
+                print(h, end=' ')
+            print("")
             for node in unprocHeaders:
                 bestContext, bestLoc = tryDAGBarrier(bestContext, node)
                 if bestLoc is not None:
                     barrierLocs.append((node, bestLoc))
 
-        print ""
-        print "Multi-parent optimization results:"
-        print "----------------------------------"
+        print("")
+        print("Multi-parent optimization results:")
+        print("----------------------------------")
         printBestOpt(bestContext)
-        print ""
+        print("")
         if len(barrierLocs) > 0:
-            print "Barrier locations:"
+            print("Barrier locations:")
             for (node, loc) in barrierLocs:
-                print "  %s: %d" % (node, loc)
+                print("  %s: %d" % (node, loc))
         else:
-            print "Multi-parent barriers do not improve results"
-        print "\n\n\n"
+            print("Multi-parent barriers do not improve results")
+        print("\n\n\n")
 
     if parallelEdge:
-        print "\nAttempting optimization of parallel edges to downstream nodes...\n"
+        print("\nAttempting optimization of parallel edges to downstream nodes...\n")
         # Insert barriers between adjacent nodes when multiple patterns cause the transition
         parallelLocs = []
         for node in ccontext.dagOrderList:
@@ -2530,33 +2537,33 @@ if __name__ == "__main__":
                         if bestLoc is not None:
                             parallelLocs.append((node, nxt, bestLoc))
 
-        print ""
-        print "Parallel edge optimization results:"
-        print "-----------------------------------"
+        print("")
+        print("Parallel edge optimization results:")
+        print("-----------------------------------")
         printBestOpt(bestContext)
-        print ""
+        print("")
         if len(parallelLocs) > 0:
-            print "Parallel edge barrier locations:"
+            print("Parallel edge barrier locations:")
             for (node, nxtNode, loc) in parallelLocs:
-                print "  %s -> %s: %d" % (node, nxtNode, loc)
+                print("  %s -> %s: %d" % (node, nxtNode, loc))
         else:
-            print "Parallel edge barriers do not improve results"
-        print "\n\n\n"
+            print("Parallel edge barriers do not improve results")
+        print("\n\n\n")
 
 
     if instMerge:
-        print "\nAttempting combining clusters that differ only by instance number...\n"
+        print("\nAttempting combining clusters that differ only by instance number...\n")
         combineClustersByInst(bestContext)
 
-    print ""
-    print "Final optimization results:"
-    print "---------------------------"
+    print("")
+    print("Final optimization results:")
+    print("---------------------------")
     printDAG(bestContext.dag)
     printBestOpt(bestContext)
-    print ""
+    print("")
     printEntries(bestContext)
     if printTCAM or saveTCAM:
-        print ""
+        print("")
         allocateResultVectorEntries(bestContext)
-        print ""
+        print("")
         printTCAMEntries(bestContext)

--- a/lib/python/DAGBarrierNode.py
+++ b/lib/python/DAGBarrierNode.py
@@ -35,5 +35,5 @@ if __name__ == '__main__':
     hdr.addField('f2', 16)
     hdr.addField('f3', 8)
     node = BarrierNode(hdr, 1, 2)
-    print node
-    print 'Total length:', node.getTotalLength()
+    print(node)
+    print('Total length:', node.getTotalLength())

--- a/lib/python/DAGChain.py
+++ b/lib/python/DAGChain.py
@@ -104,32 +104,17 @@ class DAGChain(object):
     def __eq__(self, other):
         return self.__hash__() == other.__hash__()
 
-    def __cmp__(self, other):
+    def __lt__(self, other):
         if isinstance(other, DAGChain):
-            if self.__hash__() == other.__hash__():
-                return 0
-
-            for i in xrange(min(len(self.chain), len(other.chain))):
-                c = cmp(self.chain[i], other.chain[i])
-                if c != 0:
-                    return c
-
-            if len(self.chain) < len(other.chain):
-                return -1
-            elif len(self.chain) > len(other.chain):
-                return 1
-
-            c = cmp(self.done, other.done)
-            if c != 0:
-                return c
-
-            c = cmp(self.patterns, other.patterns)
-            if c != 0:
-                return c
-
-            return 0
-        else:
-            return -1
+            for i in range(min(len(self.chain), len(other.chain))):
+                if self.chain[i] != other.chain[i]:
+                    return self.chain[i] < other.chain[i]
+            if len(self.chain) != len(other.chain):
+                return len(self.chain) < len(other.chain)
+            if self.done != other.done:
+                return self.done < other.done
+            return self.patterns < other.patterns
+        return NotImplemented
 
     def chainPop(self):
         """Pop a node from the end of the chain"""
@@ -249,7 +234,7 @@ class DAGChain(object):
             chainCopy.patterns = self.patterns
         else:
             chainCopy.calcPatterns()
-        print "ChainCopy: %s   (Depth: %d)" % (chainCopy, depth)
+        print("ChainCopy: %s   (Depth: %d)" % (chainCopy, depth))
 
         return chainCopy
 
@@ -274,7 +259,7 @@ class DAGChain(object):
             nodeLookupBytes = node.dagNode.getDecisionBytes()
             for lb in nodeLookupBytes:
                 if lb >= node.startPos and lb < node.startPos + node.read:
-                    lookupBytes.add(lb - node.startPos + offset)
+                    lookupBytes.add(int(lb - node.startPos + offset))
             offset += node.consumed
 
         lookupBytes = sorted(lookupBytes)
@@ -644,7 +629,7 @@ class DAGChain(object):
         # If we start with a barrier node, then we need to add subchains
         # for every chain up until the first containing a decision byte
         if len(self.chain) > 0: # and isinstance(self.chain[0].dagNode, BarrierNode):
-            for i in xrange(0, len(self.chain)):
+            for i in range(0, len(self.chain)):
                 cn = self.chain[i]
                 cnLookupBytes = cn.dagNode.getDecisionBytes()
                 cnLookupBytes = [lb - self.chain[i].startPos for lb in cnLookupBytes]
@@ -688,7 +673,7 @@ class DAGChain(object):
 
             seenLookupBytes = False
             firstDone = False
-            for i in xrange(len(self.chain)):
+            for i in range(len(self.chain)):
                 cn = self.chain[i]
                 cnLookupBytes = cn.dagNode.getDecisionBytes()
                 cnLookupBytes = [lb - self.chain[i].startPos for lb in cnLookupBytes]
@@ -832,7 +817,7 @@ class DAGChain(object):
 
     def getLookupByteValues(self, trim=True):
         """Return all sets of lookup byte values"""
-        print "getLookupByteValues:", self, trim
+        print("getLookupByteValues:", self, trim)
         #lookupBytes = ['']
         offset = 0
         prevOffset = 0
@@ -930,9 +915,10 @@ class DAGChain(object):
             #            newLookupBytes.append(lb + hlb)
             #    lookupBytes = newLookupBytes
 
-            prevHdrLookupBytes = map(lambda x : x + offset, prevHdrLookupBytes)
-            hdrLookupBytes = map(lambda x : x + offset, hdrLookupBytes)
+            prevHdrLookupBytes = [x + offset for x in prevHdrLookupBytes]
+            hdrLookupBytes = [x + offset for x in hdrLookupBytes]
             lookupBytes.extend(hdrLookupBytes)
+            lookupBytes = [int(lb) for lb in lookupBytes]
             if len(hdrLookupValues) > 0:
                 newLookupValues = []
                 for lv in lookupValues:
@@ -949,8 +935,8 @@ class DAGChain(object):
 
         # Assemble the lookup bytes
         if len(lookupBytes) > 0:
-            lbMin = min(lookupBytes)
-            lbMax = max(lookupBytes)
+            lbMin = int(min(lookupBytes))
+            lbMax = int(max(lookupBytes))
             offset = 0
             if lbMin < 0 and not trim:
                 offset = -lbMin
@@ -959,11 +945,11 @@ class DAGChain(object):
             sortedLookupBytes = sorted(set(lookupBytes))
             newLookupValues = []
             for lv in lookupValues:
-                mask = [0 for x in xrange(lbMax + 1)]
-                match = [0 for x in xrange(lbMax + 1)]
+                mask = [0 for x in range(lbMax + 1)]
+                match = [0 for x in range(lbMax + 1)]
 
-                for i in xrange(len(lookupBytes)):
-                    dest = lookupBytes[i]
+                for i in range(len(lookupBytes)):
+                    dest = int(lookupBytes[i])
                     dest += offset
                     if offset >= 0:
                         mask[dest] |= lv[0][i]
@@ -980,7 +966,7 @@ class DAGChain(object):
         else:
             lookupValues = ['']
 
-        print "getLookupByteValues (DONE):", self, lookupValues
+        print("getLookupByteValues (DONE):", self, lookupValues)
         #print lb2, lm2
 
 
@@ -998,4 +984,4 @@ if __name__ == '__main__':
     chain.add(chainNode1)
     chain.add(chainNode2)
 
-    print chain
+    print(chain)

--- a/lib/python/DAGChainNode.py
+++ b/lib/python/DAGChainNode.py
@@ -118,31 +118,16 @@ class DAGChainNode(object):
         #if isinstance(other, DAGChainNode):
         return self.__hash__() == other.__hash__()
 
-    def __cmp__(self, other):
-        #if isinstance(other, DAGChainNode):
-        if type(other) == DAGChainNode:
-            if self.__hash__() == other.__hash__():
-                return 0
-
-            c = cmp(self.dagNode, other.dagNode)
-            if c != 0:
-                return c
-
-            c = cmp(self.startPos, other.startPos)
-            if c != 0:
-                return c
-
-            c = cmp(self.consumed, other.consumed)
-            if c != 0:
-                return c
-
-            c = cmp(self.read, other.read)
-            if c != 0:
-                return c
-
-            return 0
-        else:
-            return -1
+    def __lt__(self, other):
+        if isinstance(other, DAGChainNode):
+            if self.dagNode != other.dagNode:
+                return self.dagNode < other.dagNode
+            if self.startPos != other.startPos:
+                return self.startPos < other.startPos
+            if self.consumed != other.consumed:
+                return self.consumed < other.consumed
+            return self.read < other.read
+        return NotImplemented
 
     def unconsumed(self):
         return self.dagNode.getLength() - self.startPos - self.consumed
@@ -186,8 +171,8 @@ if __name__ == '__main__':
     chainNode1 = DAGChainNode(dagNode1, 1, 4, 4)
     chainNode2 = DAGChainNode(dagNode1, 1, 4, 4)
     chainNode3 = DAGChainNode(dagNode2, 1, 4, 4)
-    print "Chain node 1:", chainNode1
-    print "Chain node 2:", chainNode2
-    print "Chain node 3:", chainNode3
-    print "Node 1 == Node 2?", chainNode1 == chainNode2
-    print "Node 1 == Node 3?", chainNode1 == chainNode3
+    print("Chain node 1:", chainNode1)
+    print("Chain node 2:", chainNode2)
+    print("Chain node 3:", chainNode3)
+    print("Node 1 == Node 2?", chainNode1 == chainNode2)
+    print("Node 1 == Node 3?", chainNode1 == chainNode3)

--- a/lib/python/DAGHeaderNode.py
+++ b/lib/python/DAGHeaderNode.py
@@ -46,4 +46,4 @@ if __name__ == '__main__':
     hdr = Header.Header('TestHeader')
     hdr.addField('test', 8)
     node = HeaderNode(hdr, 1)
-    print node
+    print(node)

--- a/lib/python/DAGNode.py
+++ b/lib/python/DAGNode.py
@@ -5,8 +5,7 @@
 from abc import ABCMeta, abstractmethod
 import Header
 
-class DAGNode(object):
-    __metaclass__ = ABCMeta
+class DAGNode(object, metaclass=ABCMeta):
     """A node in a DAG"""
     
     def __init__(self, hdr, inst, length):
@@ -63,11 +62,16 @@ class DAGNode(object):
         #return '%s:%03d' % (self.getName(), self.inst)
         return self._cmpName
 
-    def __cmp__(self, other):
+    def __eq__(self, other):
+        return isinstance(other, DAGNode) and self.getCmpName() == other.getCmpName()
+
+    def __lt__(self, other):
         if isinstance(other, DAGNode):
-            return cmp(self.getCmpName(), other.getCmpName())
-        else:
-            return -1
+            return self.getCmpName() < other.getCmpName()
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.getCmpName())
 
 
 # Basic test code
@@ -78,4 +82,4 @@ if __name__ == '__main__':
 
     hdr = Header.Header('TestHeader')
     node = MyDAGNode(hdr, 1, 0)
-    print node
+    print(node)

--- a/lib/python/DAGPadNode.py
+++ b/lib/python/DAGPadNode.py
@@ -41,5 +41,5 @@ if __name__ == '__main__':
     hdr = Header.Header('TestHeader')
     hdr.addField('test', 8)
     node = PadNode(hdr, 1, 4)
-    print node
-    print 'Total length:', node.getTotalLength()
+    print(node)
+    print('Total length:', node.getTotalLength())

--- a/lib/python/DAGSubHeaderNode.py
+++ b/lib/python/DAGSubHeaderNode.py
@@ -68,5 +68,5 @@ if __name__ == '__main__':
     hdr.addField('f4', 8)
     hdr.setCalcLength(['f1', '*', 2, '*', 'f3'])
     node = SubHeaderNode(hdr, 1, 1, 4)
-    print "Node:", node
-    print "Decision bytes:", node.getDecisionBytes()
+    print("Node:", node)
+    print("Decision bytes:", node.getDecisionBytes())

--- a/lib/python/Field.py
+++ b/lib/python/Field.py
@@ -36,5 +36,5 @@ class Field():
 # Basic test code
 if __name__ == '__main__':
     hdr = Field('TestField')
-    print hdr
+    print(hdr)
 

--- a/lib/python/Header.py
+++ b/lib/python/Header.py
@@ -83,7 +83,7 @@ class Header():
             optional = False
             optionalFields = []
             for field in self.fieldList:
-                if field.width >= 0:
+                if field.width is not None and field.width >= 0:
                     minLen += field.width
                 else:
                     optional = True
@@ -118,7 +118,7 @@ class Header():
         for field in self.fieldList:
             if fieldList != '':
                 fieldList += ', '
-            if field.width >= 0:
+            if field.width is not None and field.width >= 0:
                 fieldList += '%s:%d' % (field.name, field.width)
             else:
                 fieldList += '%s:?' % (field.name)
@@ -201,7 +201,7 @@ class Header():
             # Identify the bytes that need to be extracted
             pos = 0
             for field in self.fieldList + self.pseudofieldList:
-                if field.width > 0:
+                if field.width is not None and field.width > 0:
                     if field.name in fields:
                         endPos = pos + field.width
                         decPos = int((endPos - 1) / 8) + 1
@@ -223,7 +223,7 @@ class Header():
         # Identify the bytes that need to be extracted
         pos = 0
         for field in self.fieldList + self.pseudofieldList:
-            if field.width > 0:
+            if field.width is not None and field.width > 0:
                 if field.name in lengthFields:
                     endPos = pos + field.width
                     decPos = int((endPos - 1) / 8) + 1
@@ -268,16 +268,16 @@ class Header():
         # Identify the bytes that need to be extracted
         pos = 0
         for field in self.fieldList + self.pseudofieldList:
-            if field.width > 0:
+            if field.width is not None and field.width > 0:
                 if field.name in fields:
                     endPos = pos + field.width
                     firstByte = int(pos / 8)
                     lastByte = int((endPos - 1) / 8)
 
                     if len(fieldBytes) > 0 and fieldBytes[-1] == firstByte:
-                        fieldBytes += range(firstByte + 1, lastByte + 1)
+                        fieldBytes += list(range(firstByte + 1, lastByte + 1))
                     else:
-                        fieldBytes += range(firstByte, lastByte + 1)
+                        fieldBytes += list(range(firstByte, lastByte + 1))
 
                     fieldPos[field.name] = (len(fieldBytes) - (lastByte - firstByte) - 1, pos % 8)
 
@@ -307,7 +307,7 @@ class Header():
         mask = 0
         data = 0
 
-        for i in xrange(numFields):
+        for i in range(numFields):
             field = fields[i]
             startPos = fieldPos[field]
             if field in self.fields:
@@ -332,7 +332,7 @@ class Header():
 
         contentMask = [0] * numBytes
         contentData = [0] * numBytes
-        for i in xrange(numBytes):
+        for i in range(numBytes):
             contentMask[i] = int((mask >> (8 * (numBytes - i - 1))) & 0xff)
             contentData[i] = int((data >> (8 * (numBytes - i - 1))) & 0xff)
 
@@ -401,12 +401,12 @@ class Header():
         map1 = []
         map2 = []
         for field in fieldBytes1:
-            for i in xrange(numBytes):
+            for i in range(numBytes):
                 if field == mergedFieldBytes[i]:
                     map1.append(i)
                     break
         for field in fieldBytes2:
-            for i in xrange(numBytes):
+            for i in range(numBytes):
                 if field == mergedFieldBytes[i]:
                     map2.append(i)
                     break
@@ -431,11 +431,11 @@ class Header():
         mask = [0] * numBytes
         data = [0] * numBytes
 
-        for i in xrange(len(content1[0])):
+        for i in range(len(content1[0])):
             mask[map1[i]] |= content1[0][i]
             data[map1[i]] |= content1[1][i]
 
-        for i in xrange(len(content2[0])):
+        for i in range(len(content2[0])):
             mask[map2[i]] |= content2[0][i]
             data[map2[i]] |= content2[1][i]
 
@@ -542,7 +542,7 @@ class Header():
     def getLookupLengthFields(self):
         """Get a merged list of lookup/length fields"""
         fields = self.getLookupFields() + self.getLengthFields()
-        for pos in xrange(len(fields)):
+        for pos in range(len(fields)):
             field = fields[pos]
             firstLoc = self.getFieldByteLocs([field])[0][0]
             fields[pos] = (firstLoc, field)
@@ -565,7 +565,7 @@ class Header():
             term = 0
             calcLen = -1
             valMap = {}
-            for i in xrange(len(vals)):
+            for i in range(len(vals)):
                 valMap[lengthVars[i]] = 0
             while calcLen < maxLen and term < 255:
                 calcLen = self.doLengthCalc(valMap)
@@ -641,7 +641,7 @@ class Header():
         lengths = [x / 8 for x in lengths]
         minLength = min(lengths)
         
-        if desiredLength < minLength:
+        if desiredLength != ANY and desiredLength < minLength:
             desiredLength = ANY
 
         # Walk through the combination of lengths and next headers
@@ -668,7 +668,7 @@ class Header():
                     fieldMatch = self.getFieldByteContentsSingle(fields, vals, fieldBytes, fieldPos)
 
                     # Walk through all of the possible lengths
-                    for i in xrange(len(lengths)):
+                    for i in range(len(lengths)):
                         length = lengths[i]
                         if lenIsVariable:
                             match = self.mergeContents(mergedFieldBytes, map1, map2, fieldMatch, lenContent[i])
@@ -681,7 +681,7 @@ class Header():
             mergedFieldBytes = lenFieldBytes
 
             # Case: no next header
-            for i in xrange(len(lengths)):
+            for i in range(len(lengths)):
                 length = lengths[i]
                 if lenIsVariable:
                     match = lenContent[i]
@@ -698,7 +698,7 @@ class Header():
 
         for match in matches:
             matchStr = ""
-            for i in xrange(numDecBytes):
+            for i in range(numDecBytes):
                 matchStr += "%02x%02x" % (match[0][i], match[1][i])
             matchStrs.add(matchStr)
 
@@ -725,7 +725,7 @@ class Header():
         lengths = [x / 8 for x in lengths]
         minLength = min(lengths)
         
-        if desiredLength < minLength:
+        if desiredLength != ANY and desiredLength < minLength:
             desiredLength = ANY
 
         # Walk through the combination of lengths and next headers
@@ -752,7 +752,7 @@ class Header():
                     fieldMatch = self.getFieldByteContentsSingle(fields, vals, fieldBytes, fieldPos)
 
                     # Walk through all of the possible lengths
-                    for i in xrange(len(lengths)):
+                    for i in range(len(lengths)):
                         length = lengths[i]
                         if lenIsVariable:
                             match = self.mergeContents(mergedFieldBytes, map1, map2, fieldMatch, lenContent[i])
@@ -765,7 +765,7 @@ class Header():
             mergedFieldBytes = lenFieldBytes
 
             # Case: no next header
-            for i in xrange(len(lengths)):
+            for i in range(len(lengths)):
                 length = lengths[i]
                 if lenIsVariable:
                     match = lenContent[i]
@@ -782,7 +782,7 @@ class Header():
 
         for match in matches:
             matchStr = ""
-            for i in xrange(numDecBytes):
+            for i in range(numDecBytes):
                 matchStr += "%02x%02x" % (match[0][i], match[1][i])
             matchStrs.add(matchStr)
 
@@ -803,7 +803,7 @@ class Header():
         lengths = [x / 8 for x in lengths]
         minLength = min(lengths)
         
-        if desiredLength < minLength:
+        if desiredLength != ANY and desiredLength < minLength:
             desiredLength = ANY
 
         # Walk through the combination of lengths and next headers
@@ -830,7 +830,7 @@ class Header():
                     fieldMatch = self.getFieldByteContentsSingle(fields, vals, fieldBytes, fieldPos)
 
                     # Walk through all of the possible lengths
-                    for i in xrange(len(lengths)):
+                    for i in range(len(lengths)):
                         length = lengths[i]
                         if lenIsVariable:
                             match = self.mergeContents(mergedFieldBytes, map1, map2, fieldMatch, lenContent[i])
@@ -843,7 +843,7 @@ class Header():
             mergedFieldBytes = lenFieldBytes
 
             # Case: no next header
-            for i in xrange(len(lengths)):
+            for i in range(len(lengths)):
                 length = lengths[i]
                 if lenIsVariable:
                     match = lenContent[i]
@@ -860,7 +860,7 @@ class Header():
 
         for match in matches:
             matchStr = ""
-            for i in xrange(numDecBytes):
+            for i in range(numDecBytes):
                 matchStr += "%02x%02x" % (match[0][i], match[1][i])
             matchStrs.add(matchStr)
 
@@ -868,7 +868,7 @@ class Header():
 
         newMatches = []
         for match in matchStrs:
-            matchValueByteArray = map(ord, match.decode('hex'))
+            matchValueByteArray = list(bytes.fromhex(match))
             newMatches.append((matchValueByteArray[0::2], matchValueByteArray[1::2]))
 
         return mergedFieldBytes[0:numDecBytes], newMatches
@@ -886,7 +886,7 @@ class Header():
                 lengths = []
                 for lenFieldValSet in lenFieldVals:
                     valMap = {}
-                    for i in xrange(len(lenFields)):
+                    for i in range(len(lenFields)):
                         valMap[lenFields[i]] = lenFieldValSet[i]
                     lengths.append(self.doLengthCalc(valMap))
 
@@ -920,8 +920,8 @@ class Header():
                 bit = fieldWidths[part] - 1
                 while not cFound and bit >= 0:
                     #print part, bit
-                    for lPos in xrange(len(matches)):
-                        for rPos in xrange(lPos + 1, len(matches)):
+                    for lPos in range(len(matches)):
+                        for rPos in range(lPos + 1, len(matches)):
                             (leftMask, leftMatch) = matches[lPos]
                             (rightMask, rightMatch) = matches[rPos]
                             if leftMask == rightMask:
@@ -929,9 +929,9 @@ class Header():
                                 newMask[part] &= (2 ** fieldWidths[part] - 1) ^ (2 ** bit)
                                 #print lPos, rPos, part, bit, leftMask, newMask
                                 leftMatchNew = [leftMatch[i] & newMask[i] for
-                                        i in xrange(numParts)]
+                                        i in range(numParts)]
                                 rightMatchNew = [rightMatch[i] & newMask[i] for
-                                        i in xrange(numParts)]
+                                        i in range(numParts)]
                                 #print leftMatch, leftMatchNew, rightMatch, rightMatchNew
                                 if leftMatchNew == rightMatchNew:
                                     #if cPos not in candidates:
@@ -956,12 +956,12 @@ class Header():
                     newMask = copy.copy(leftMask)
                     newMask[part] &= (2 ** fieldWidths[part] - 1) ^ (2 ** bit)
                     newMatch = [leftMatch[i] & newMask[i] for i in
-                            xrange(numParts)]
+                            range(numParts)]
                     mergedPositions.add(lPos)
                     mergedPositions.add(rPos)
                     mergedMatches.append((newMask, newMatch))
                     merged = True
-            for i in xrange(len(matches)):
+            for i in range(len(matches)):
                 if i not in mergedPositions:
                     mergedMatches.append(matches[i])
             #print "MergedMatches:", mergedMatches
@@ -1004,5 +1004,5 @@ class Header():
 # Basic test code
 if __name__ == '__main__':
     hdr = Header('TestHeader')
-    print hdr
+    print(hdr)
 

--- a/lib/python/HeaderLib.py
+++ b/lib/python/HeaderLib.py
@@ -59,7 +59,7 @@ def getHeaderLengths(hdr):
             lengths = []
             for lenFieldValSet in lenFieldVals:
                 valMap = {}
-                for i in xrange(len(lenFields)):
+                for i in range(len(lenFields)):
                     valMap[lenFields[i]] = lenFieldValSet[i]
                 lengths.append(hdr.doLengthCalc(valMap))
 
@@ -148,7 +148,7 @@ def exploreHeader(hdr, headers, callback, callPerLenNxtHdr = True):
                 fieldMatch = hdr.getFieldByteContentsSingle(fields, vals, fieldBytes, fieldPos)
 
                 # Walk through all of the possible lengths
-                for i in xrange(len(lengths)):
+                for i in range(len(lengths)):
                     length = lengths[i]
                     if lenIsVariable:
                         match = hdr.mergeContents(mergedFieldBytes, map1, map2, fieldMatch, lenContent[i])
@@ -184,7 +184,7 @@ def exploreHeader(hdr, headers, callback, callPerLenNxtHdr = True):
     else:
         # Case: no next header
         if callPerLenNxtHdr:
-            for i in xrange(len(lengths)):
+            for i in range(len(lengths)):
                 length = lengths[i]
                 if lenIsVariable:
                     match = lenContent[i]
@@ -234,13 +234,13 @@ if __name__ == "__main__":
         exploreHeader(headerList[0], headers, exploreHdrChain)
 
         for path in sorted(finalPaths):
-            print path
+            print(path)
 
 
     seenHdrs = set()
     def exploreHdrChainMerged(hdr, headers, hdrInfo):
         if not hdr.name in seenHdrs:
-            print hdr.name
+            print(hdr.name)
             seenHdrs.add(hdr.name)
 
             for nxtHdr in hdrInfo.nxtHdrs:
@@ -258,13 +258,13 @@ if __name__ == "__main__":
     args = my_parser.parse_args()
 
     (headerList, headers) = readHeaders(args.hdr_file)
-    print "List of headers (from walk)"
-    print "==========================="
+    print("List of headers (from walk)")
+    print("===========================")
     exampleHeaderWalkMerged(headerList[0], headers)
-    print "\n"
+    print("\n")
 
-    print "Header paths"
-    print "============"
+    print("Header paths")
+    print("============")
     exampleHeaderWalk(headerList[0], headers)
 
 def crackKey(hdr, key, fields):
@@ -306,7 +306,7 @@ def getHeaderBNF():
     global headerBNF
 
     if not headerBNF:
-        LBRACE, RBRACE, COLON, COMMA, EQ, LPAREN, RPAREN = map(Suppress, "{}:,=()")
+        LBRACE, RBRACE, COLON, COMMA, EQ, LPAREN, RPAREN = list(map(Suppress, "{}:,=()"))
         identifier = Word(alphas,alphanums+'_'+'-')
         identifierOrStar = Or(Literal('*'), identifier)
         integer = Word(nums)
@@ -439,14 +439,14 @@ def readHeaders(filename):
 
                             # Approximate counting of the number of entries covered
                             wildcards = 0
-                            for i in xrange(len(widths)):
+                            for i in range(len(widths)):
                                 fieldWidth = widths[i]
                                 fieldMask = mask[i]
-                                wildcards += sum([(~fieldMask >> shift) & 1 for shift in xrange(fieldWidth)])
+                                wildcards += sum([(~fieldMask >> shift) & 1 for shift in range(fieldWidth)])
                             rangeCount += 2 ** wildcards
 
                     # Attempt to sort the header map by key
-                    keys = hdrMap.keys()
+                    keys = list(hdrMap.keys())
                     keys.sort()
                     hdrList = []
                     for key in keys:
@@ -465,29 +465,32 @@ def readHeaders(filename):
                 (mask, data) = crackKey(hdr, item.next_header_def[0], from_fields)
                 hdr.setDefNxtHdrVal((mask, data))
 
-            if item.maxvar != '':
-                item.maxvar = str(item.maxvar)
-                if item.maxvar not in refCounts:
-                    refCounts[item.maxvar] = RefCount(item.maxvar)
-                hdr.setRefCount(refCounts[item.maxvar])
+            maxvar = getattr(item, 'maxvar', '')
+            if maxvar != '':
+                maxvar = str(maxvar)
+                if maxvar not in refCounts:
+                    refCounts[maxvar] = RefCount(maxvar)
+                hdr.setRefCount(refCounts[maxvar])
 
-            if item.maxval != '':
+            maxval = getattr(item, 'maxval', '')
+            if maxval != '':
                 if not hdr.getRefCount():
                     if item.hdr not in refCounts:
                         refCounts[item.hdr] = RefCount(item.hdr)
                     hdr.setRefCount(refCounts[item.hdr])
-                hdr.getRefCount().setMax(int(item.maxval[0]))
+                hdr.getRefCount().setMax(int(maxval[0]))
 
-            if item.hdr_len != '':
+            hdr_len = getattr(item, 'hdr_len', '')
+            if hdr_len != '':
                 newExp = []
-                if type(item.hdr_len[0]) == str:
-                    newExp.append(item.hdr_len[0])
+                if type(hdr_len[0]) == str:
+                    newExp.append(hdr_len[0])
                 else:
                     #print item.hdr_len[0]
                     #print type(item.hdr_len[0])
                     #print len(item.hdr_len[0])
                     #print len(item.hdr_len.asList())
-                    for exp in item.hdr_len[0]:
+                    for exp in hdr_len[0]:
                         if intRE.match(exp):
                             exp = int(exp)
                             newExp.append(exp)
@@ -496,15 +499,16 @@ def readHeaders(filename):
                         else:
                             newExp.append(exp)
                 hdr.setCalcLength(newExp)
-                
-                #hdr.setMax(int(item.maxval[0]))
 
-            if item.max_len != '':
-                hdr.setMaxLength(int(item.max_len[0]))
+                #hdr.setMax(int(maxval[0]))
+
+            max_len = getattr(item, 'max_len', '')
+            if max_len != '':
+                hdr.setMaxLength(int(max_len[0]))
                 
             #print hdr
         else:
-            print "Error: header '%s' seen multiple times" % item.hdr
+            print("Error: header '%s' seen multiple times" % item.hdr)
             sys.exit(-1)
         #print hdr
 
@@ -543,12 +547,12 @@ def mergeTransitions(headerList, headers):
                 if isinstance(mergedHeader.nextHeader, tuple):
                     mergedHeader.nextHeader = copy.deepcopy(mergedHeader.nextHeader)
                     from_fields = mergedHeader.nextHeader[0]
-                    for i in xrange(len(from_fields)):
+                    for i in range(len(from_fields)):
                         from_fields[i] = '%d-%s' % (pos, from_fields[i])
                     #print from_fields
 
                 if hdr.getRefCount() and nextHdr.getRefCount():
-                    print "Headers being merged both have a reference count. Exiting..."
+                    print("Headers being merged both have a reference count. Exiting...")
                     sys.exit(-1)
                 elif hdr.getRefCount():
                     mergedHeader.setRefCount(hdr.getRefCount())
@@ -556,17 +560,17 @@ def mergeTransitions(headerList, headers):
                     mergedHeader.setRefCount(nextHdr.getRefCount())
 
                 if hdr.calcLength:
-                    print "First header being merged has a calculated length. Unable to merge..."
+                    print("First header being merged has a calculated length. Unable to merge...")
                     sys.exit(-1)
                 elif nextHdr.calcLength:
                     newExp = [hdr.length()[0], '+'] + nextHdr.calcLength
-                    for i in xrange(len(newExp)):
+                    for i in range(len(newExp)):
                         if isinstance(newExp[i], str) and not opRE.match(newExp[i]):
                             newExp[i] = '%d-%s' % (pos, newExp[i])
                     mergedHeader.setCalcLength(newExp)
 
                 if hdr.maxLength:
-                    print "First header being merged has a max length. Unable to merge..."
+                    print("First header being merged has a max length. Unable to merge...")
                     sys.exit(-1)
                 elif nextHdr.maxLength:
                     mergedHeader.setMaxLength(hdr.length()[0] + nextHdr.maxLength)
@@ -583,7 +587,7 @@ def mergeTransitions(headerList, headers):
         if hdr.nextHeader:
             if isinstance(hdr.nextHeader, tuple):
                 hdrList = hdr.nextHeader[1]
-                for i in xrange(len(hdrList)):
+                for i in range(len(hdrList)):
                     nxtHdrName = hdrList[i][1]
                     if nxtHdrName in remapHdrs:
                         hdrList[i] = (hdrList[i][0], remapHdrs[nxtHdrName])
@@ -640,19 +644,19 @@ if __name__ == "__main__":
 
     (headerList, headers) = readHeaders(args.hdr_file)
 
-    print "Headers:",
+    print("Headers:", end=' ')
     for hdr in headerList:
-        print hdr.name,
-    print ""
+        print(hdr.name, end=' ')
+    print("")
 
     for hdr in headerList:
         (l, m, o, oList) = hdr.length()
 
         if not o:
-            print "%s:%d" % (hdr.name, l)
+            print("%s:%d" % (hdr.name, l))
         else:
             if m:
-                print "%s:%d+* (max: %d)" % (hdr.name, l, m)
-                print "  Header fields: %s" % str(hdr.getLengthVarValues())
+                print("%s:%d+* (max: %d)" % (hdr.name, l, m))
+                print("  Header fields: %s" % str(hdr.getLengthVarValues()))
             else:
-                print "%s:%d+*" % (hdr.name, l)
+                print("%s:%d+*" % (hdr.name, l))

--- a/lib/python/OptContext.py
+++ b/lib/python/OptContext.py
@@ -4,9 +4,8 @@
 
 from abc import ABCMeta, abstractmethod
 
-class OptContext(object):
+class OptContext(object, metaclass=ABCMeta):
     """Optimal chain graph node"""
-    __metaclass__ = ABCMeta
 
     runs = 0
 
@@ -48,5 +47,5 @@ if __name__ == '__main__':
     chain.add(chainNode2)
 
     optNode = OptNode(chain, 8, chain, None)
-    print optNode
+    print(optNode)
 

--- a/lib/python/OptNode.py
+++ b/lib/python/OptNode.py
@@ -8,8 +8,7 @@ from DAGHeaderNode import HeaderNode
 from DAGChainNode import DAGChainNode
 from DAGChain import DAGChain
 
-class OptNode(object):
-    __metaclass__ = ABCMeta
+class OptNode(object, metaclass=ABCMeta):
     """Optimal chain graph node"""
 
     def __init__(self, chain, bpc, cover, fringe):
@@ -25,15 +24,13 @@ class OptNode(object):
         #self._shortStr = "%s@%03d" % (self.dagNode.shortStr(), self.loc)
         #self._cmpName = "%s:%03d" % (self.dagNode.getCmpName(), self.loc)
 
-    def __cmp__(self, other):
-        if type(other) == OptNode:
-            c = cmp(self.chain, other.chain)
-            if c != 0:
-                return c
+    def __eq__(self, other):
+        return isinstance(other, OptNode) and self.chain == other.chain
 
-            return 0
-        else:
-            return -1
+    def __lt__(self, other):
+        if isinstance(other, OptNode):
+            return self.chain < other.chain
+        return NotImplemented
 
     def __str__(self):
         if self._str is None:
@@ -52,4 +49,4 @@ if __name__ == '__main__':
     chain.add(chainNode2)
 
     optNode = OptNode(chain, 8, chain, None)
-    print optNode
+    print(optNode)

--- a/lib/python/RefCount.py
+++ b/lib/python/RefCount.py
@@ -37,4 +37,4 @@ class RefCount():
 # Basic test code
 if __name__ == '__main__':
     refCount = RefCount('Example')
-    print refCount
+    print(refCount)


### PR DESCRIPTION
## Summary
- Harden header parsing against missing optional fields when using pyparsing 3
- Add comparison and hashing methods for DAG classes and update TCAM generator to Python 3 APIs
- Replace legacy hex decoding and time.clock usage for full Python 3 runtime

## Testing
- `PYTHONPATH=lib/python python bin/make_tcam.py examples/headers-simple.txt --save-tcam --no-print-tcam`


------
https://chatgpt.com/codex/tasks/task_e_68aff229f338832098cd09b8d54303e5